### PR TITLE
Fixes to variable detection

### DIFF
--- a/regresql/config.go
+++ b/regresql/config.go
@@ -58,7 +58,7 @@ func (s *Suite) readConfig() (config, error) {
 	data, err := ioutil.ReadFile(configFile)
 
 	if err != nil {
-		return config, fmt.Errorf("Failed to read config '%s': ",
+		return config, fmt.Errorf("Failed to read config '%s': %s",
 			configFile,
 			err)
 	}

--- a/regresql/regresql.go
+++ b/regresql/regresql.go
@@ -34,15 +34,15 @@ func Init(root string, pguri string) {
 	suite.Println()
 
 	fmt.Println("")
-	fmt.Println(`Empty test plans have been created in '%s'.
-Edit the plans to add query binding values, then run 
-
-  regresql update
-
-to create the expected regression files for your test plans. Plans are
-simple YAML files containing multiple set of query parameter bindings. The
-default plan files contain a single entry named "1", you can rename the test
-case and add a value for each parameter. `,
+	fmt.Printf(`Empty test plans have been created in '%s'.\n
+Edit the plans to add query binding values, then run\n
+\n
+  regresql update\n
+\n
+to create the expected regression files for your test plans. Plans are\n
+simple YAML files containing multiple set of query parameter bindings. The\n
+default plan files contain a single entry named "1", you can rename the test\n
+case and add a value for each parameter.\n `,
 		suite.PlanDir)
 }
 

--- a/regresql/sql.go
+++ b/regresql/sql.go
@@ -10,7 +10,7 @@ import (
 // the psql support for variables:
 // https://www.postgresql.org/docs/9.6/static/app-psql.html#APP-PSQL-VARIABLES
 const (
-	psqlVarRE = `:['"]?([A-Za-z][A-Za-z0-9]*)['"]?`
+	psqlVarRE = `:['"]?([A-Za-z][A-Za-z0-9_]*)['"]?`
 )
 
 /*

--- a/regresql/sql.go
+++ b/regresql/sql.go
@@ -10,7 +10,7 @@ import (
 // the psql support for variables:
 // https://www.postgresql.org/docs/9.6/static/app-psql.html#APP-PSQL-VARIABLES
 const (
-	psqlVarRE = `:['"]?([A-Za-z][A-Za-z0-9_]*)['"]?`
+	psqlVarRE = `[^:]:['"]?([A-Za-z][A-Za-z0-9_]*)['"]?`
 )
 
 /*

--- a/regresql/sql_test.go
+++ b/regresql/sql_test.go
@@ -13,6 +13,15 @@ func TestParseQueryString(t *testing.T) {
 	}
 }
 
+func TestParseQueryStringWithTypeCast(t *testing.T) {
+	queryString := `select name::text from foo where id = :user_id`
+	q := parseQueryString("no/path", queryString)
+
+	if len(q.Vars) != 1 || q.Vars[0] != "user_id" {
+		t.Error("Expected only [\"user_id\"], got ", q.Vars)
+	}
+}
+
 func TestPrepareOneParam(t *testing.T) {
 	queryString := `select * from foo where id = :id`
 	q := parseQueryString("no/path", queryString)

--- a/regresql/sql_test.go
+++ b/regresql/sql_test.go
@@ -5,11 +5,11 @@ import (
 )
 
 func TestParseQueryString(t *testing.T) {
-	queryString := `select * from foo where id = :id`
+	queryString := `select * from foo where id = :user_id`
 	q := parseQueryString("no/path", queryString)
 
-	if len(q.Vars) != 1 || q.Vars[0] != "id" {
-		t.Error("Expected [\"id\"], got ", q.Vars)
+	if len(q.Vars) != 1 || q.Vars[0] != "user_id" {
+		t.Error("Expected [\"user_id\"], got ", q.Vars)
 	}
 }
 


### PR DESCRIPTION
> The name must consist of letters (including non-Latin letters), digits, and underscores.

Not getting into non-Latin letters for now